### PR TITLE
Typo

### DIFF
--- a/src/epub/text/book-4.xhtml
+++ b/src/epub/text/book-4.xhtml
@@ -275,7 +275,7 @@
 				<br/>
 				<span>The mounds, the works, the walls, neglected lie,</span>
 				<br/>
-				<span>Short of their promis’d heighth, that seem’d to threat the sky.</span>
+				<span>Short of their promis’d height, that seem’d to threat the sky.</span>
 			</p>
 			<p>
 				<span>But when imperial Juno, from above,</span>


### PR DESCRIPTION
heighth -> height
This typo is also in the original page scans (but not in the physical copy of the book that I have).